### PR TITLE
Fix: specify emsg version

### DIFF
--- a/src/emsg/cli/emsg.py
+++ b/src/emsg/cli/emsg.py
@@ -31,7 +31,7 @@ parser.add_argument(
 parser.add_argument(
     "--box_version",
     default=DEFAULT_BOX_VERSION,
-    choices=[0, 1],
+    choices=["0", "1"],
     help="set emsg box version (default={})".format(DEFAULT_BOX_VERSION),
 )
 parser.add_argument(


### PR DESCRIPTION
# Problem

Cannot specify emsg box version via CLI.

```shell
(.venv) $ emsg % emsg --box_version 0
usage: emsg [-h] [-v] [-o OUT] [-s SCHEME_ID_URI] [--box_version {0,1}] [-i ID]
            [--value VALUE] [-m MESSAGE_DATA] [--presentation_time PRESENTATION_TIME]
            [--presentation_time_delta PRESENTATION_TIME_DELTA]
            [--timescale TIMESCALE] [--event_duration EVENT_DURATION]
emsg: error: argument --box_version: invalid choice: '0' (choose from 0, 1)
```

# Reason

Arguments of types which are passed to python are "string".

# Confirm

```shell
(.venv) $ emsg % emsg --box_version 0                      
(.venv) $ emsg %
```
